### PR TITLE
Add Custom field mappings

### DIFF
--- a/CreateReleaseBoardItem/src/WorkItemBuilder.ts
+++ b/CreateReleaseBoardItem/src/WorkItemBuilder.ts
@@ -28,7 +28,13 @@ export class WorkItemBuilder {
 
     public async createWorkItem(type: string) {
         const options = { additionalHeaders: { 'Content-Type': 'application/json-patch+json'}};
-        await Api.instance.post(UrlHelper.urlWorkItem(type), this._createObject, options);
+        const result = await Api.instance.post(UrlHelper.urlWorkItem(type), this._createObject, options);
+
+        if (result !== null)
+            console.log('Succesfully created work item')
+        else
+            console.log('Failed to create work item');
+
         this._createObject = [];
     }
 }

--- a/CreateReleaseBoardItem/src/index.ts
+++ b/CreateReleaseBoardItem/src/index.ts
@@ -18,7 +18,7 @@ async function run() {
         const workItemType = tl.getInputRequired('workItemType');
         const areaPath = tl.getInputRequired('areaPath');
         const iterationPath = tl.getInputRequired('iterationPath');
-        const description =tl.getInput('description') ?? '';
+        const description = tl.getInput('description') ?? '';
         const additionalTags = tl.getInput('additionalTags') ?? '';
         const customFieldMappings = tl.getDelimitedInput('customFieldMappings', '\n', false);
 

--- a/CreateReleaseBoardItem/src/index.ts
+++ b/CreateReleaseBoardItem/src/index.ts
@@ -9,7 +9,7 @@ async function run() {
         const collectionUrl = tl.getVariable('System.CollectionUri') ?? '<organization url: https://dev.azure.com/{orgName}/>';
         const accessToken = tl.getVariable('System.AccessToken') ?? '<access token>';
         const repositoryName = tl.getVariable('Build.Repository.Name') ?? "<repository name>";
-        const gitCommitId =  tl.getVariable('Build.SourceVersion') ?? "<git commit ID>";
+        const gitCommitId = tl.getVariable('Build.SourceVersion') ?? "<git commit ID>";
         const buildId = tl.getVariable('Build.BuildId') ?? '<build ID>';
 
         // input variables
@@ -18,8 +18,9 @@ async function run() {
         const workItemType = tl.getInputRequired('workItemType');
         const areaPath = tl.getInputRequired('areaPath');
         const iterationPath = tl.getInputRequired('iterationPath');
-        const description = tl.getInput('description') ?? '';
+        const description =tl.getInput('description') ?? '';
         const additionalTags = tl.getInput('additionalTags') ?? '';
+        const customFieldMappings = tl.getDelimitedInput('customFieldMappings', '\n', false);
 
         Api.instance.initialize(collectionUrl, teamProject, accessToken);
 
@@ -42,6 +43,13 @@ async function run() {
         builder.addField(WorkItemFieldHelper.iterationPath, iterationPath);
         builder.addField(WorkItemFieldHelper.descriptionField, description);
         builder.addRelation('Build', `vstfs:///Build/Build/${buildId}`, 'ArtifactLink');
+        customFieldMappings.forEach(field => {
+            const split = field.split('=');
+            if (split.length != 2)
+                return;
+
+            builder.addField(`/fields/${split[0]}`, split[1]);
+        })
 
         if (labels)
             builder.addField(WorkItemFieldHelper.tagPath, labels);

--- a/CreateReleaseBoardItem/task.json
+++ b/CreateReleaseBoardItem/task.json
@@ -61,13 +61,22 @@
             "defaultValue": "",
             "required": false,
             "helpMarkDown": "The description of the work item"
-        },        {
+        },
+        {
             "name": "additionalTags",
             "type": "string",
             "label": "Additional tags",
             "defaultValue": "",
             "required": false,
             "helpMarkDown": "Any additional tags you want to add to the work item"
+        },
+        {
+            "name": "customFieldMappings",
+            "type": "multiLine",
+            "label": "Add data to other fields not automatically filled",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Provide each field on a new line with field=value syntax"
         }
     ],
     "execution": {

--- a/CreateReleaseBoardItem/task.json
+++ b/CreateReleaseBoardItem/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 0,
         "Minor": 0,
-        "Patch": 1
+        "Patch": 2
     },
     "instanceNameFormat": "Creating work item...",
     "inputs": [

--- a/README.md
+++ b/README.md
@@ -22,3 +22,9 @@
 
 ## Running locally
 Use `$env:INPUT_{variableName}` to set an input variable
+
+## For personal testing
+Update in both `task.json` and `vvs-extension.json`
+GUID: 55a2ce16-f56a-4f4d-a059-80771be38bce
+Name: PREVIEWCreateReleaseBoardItem
+Friendly name: (PREVIEW) Create release board work item

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@
     workItemType: 'User Story'
     title: 'Hello world'
     description: 'some description'
+    customFieldMappings: |
+      Custom.MyField=$(Build.SourceVersionMessage)
+      Custom.MySecondField=Test 1234
 ```
 
 ## Running locally

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "CreateReleaseBoardItem",
     "name": "Create release board work item",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "publisher": "evdbogaard",
     "targets": [
         {


### PR DESCRIPTION
Adds an extra input that allows for mapping of fields not set automatically.

Fields need to be separated by an `=` sign and each field needs to be put on a new line.

Small example:
``` 
customFieldMappings: |
  Custom.MyField=$(Build.SourceVersionMessage)
  Custom.MySecondField=Test 1234
```